### PR TITLE
Keep command history clean when using autopairs and surround

### DIFF
--- a/share/kcr/rc/auto-pairs.kak
+++ b/share/kcr/rc/auto-pairs.kak
@@ -99,8 +99,8 @@ define-command -override -hidden handle-inserted-opening-pair -params 2 %{
     }
 
     # Add insert mappings
-    map -docstring 'insert character or move right in pair' window insert %arg{2} "<a-;>:auto-pairs-insert-character %%🐈%arg{2}🐈<ret>"
-    map -docstring 'insert a new indented line in pair' window insert <ret> '<a-;>:auto-pairs-insert-new-line<ret>'
+    map -docstring 'insert character or move right in pair' window insert %arg{2} "<a-;>: auto-pairs-insert-character %%🐈%arg{2}🐈<ret>"
+    map -docstring 'insert a new indented line in pair' window insert <ret> '<a-;>: auto-pairs-insert-new-line<ret>'
 
     # Keep the track of inserted pairs
     increment-inserted-pairs-count

--- a/share/kcr/rc/surround.kak
+++ b/share/kcr/rc/surround.kak
@@ -43,9 +43,9 @@ define-command -override -hidden surround-init %{
 
 # Declare surrounding pairs
 define-command -override declare-surrounding-pair -params 4 -docstring 'declare-surrounding-pair <description> [alias] <opening> <closing>: declare surrounding pair' %{
-  try %{ map -docstring %arg{1} global surround %arg{2} ":surround-add %%🐈%arg{3}🐈 %%🐈%arg{4}🐈<ret>" }
-  try %{ map -docstring %arg{1} global surround %arg{3} ":surround-add %%🐈%arg{3}🐈 %%🐈%arg{4}🐈<ret>" }
-  try %{ map -docstring %arg{1} global surround %arg{4} ":surround-add %%🐈%arg{3}🐈 %%🐈%arg{4}🐈<ret>" }
+  try %{ map -docstring %arg{1} global surround %arg{2} ": surround-add %%🐈%arg{3}🐈 %%🐈%arg{4}🐈<ret>" }
+  try %{ map -docstring %arg{1} global surround %arg{3} ": surround-add %%🐈%arg{3}🐈 %%🐈%arg{4}🐈<ret>" }
+  try %{ map -docstring %arg{1} global surround %arg{4} ": surround-add %%🐈%arg{3}🐈 %%🐈%arg{4}🐈<ret>" }
 }
 
 # Enter insert mode


### PR DESCRIPTION
I noticed these commands occasionally appear in command history, when I press `:` in kakoune. With this change they would hopefully stay invisible for the user.