### PR TITLE
Drop autofocus behavior on edit command

### DIFF
--- a/src/kakoune/client.cr
+++ b/src/kakoune/client.cr
@@ -34,8 +34,6 @@ class Kakoune::Client
       if position
         string.puts(Arguments.quote("edit", files.first.to_s, position.line.to_s, position.column.to_s))
       end
-
-      string.puts("try focus")
     end
 
     send(command)


### PR DESCRIPTION
As this is a strong and restrictive behavior that only works on some
terminal multiplexer and rely on user additional scripts to works on other
contexts, we drop this autofocus behavior

resolve : https://github.com/alexherbo2/kakoune.cr/issues/36