### PR TITLE
Enforce the EDITOR "kcr edit" value on connect

### DIFF
--- a/share/kcr/init/kakoune.kak
+++ b/share/kcr/init/kakoune.kak
@@ -6,6 +6,8 @@ define-command -override connect -params 1.. -command-completion -docstring 'Run
     export KAKOUNE_CLIENT=$2
     shift 3
 
+    export EDITOR='kcr edit'
+
     [ $# = 0 ] && set "$SHELL"
 
     "$@"


### PR DESCRIPTION
As this looks like the most expected behavior, requiring the user to
configure it somehow looks wrong.

This enforce the value and make the connect command to works ootb
without additional configuration. Example:

:connect terminal nnn